### PR TITLE
feat: improve taskbar-grouping to handle pinned items

### DIFF
--- a/mods/taskbar-grouping.wh.cpp
+++ b/mods/taskbar-grouping.wh.cpp
@@ -2,8 +2,8 @@
 // @id              taskbar-grouping
 // @name            Disable grouping on the taskbar
 // @description     Causes a separate button to be created on the taskbar for each new window
-// @version         1.0
-// @author          m417z
+// @version         1.1
+// @author          m417z, ZimM
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
 // @homepage        https://m417z.com/
@@ -28,7 +28,7 @@ Windows 10 64-bit and Windows 11.
 ## Limitations
 
 This is an early implementation which has several limitations:
-* Pinned items are separated as well.
+* Pinned items might become separated in some cases.
 * The jump list menu might be missing items such as recent files.
 * The mod has no effect on UWP/Store apps.
 
@@ -36,6 +36,11 @@ For a more complete solution for Windows 7, 8 and 10,
 check out [7+ Taskbar Tweaker](https://rammichael.com/7-taskbar-tweaker).
 */
 // ==/WindhawkModReadme==
+
+#include <utility>
+#include <vector>
+#include <string>
+#include <mutex>
 
 typedef HRESULT (WINAPI *GetAppIDForWindow_t)(
     LPVOID pThis,
@@ -60,6 +65,21 @@ GetAppIDForWindow_t pOriginalGetAppIDForWindow;
 GetShortcutForProcess_t pOriginalGetShortcutForProcess;
 GetBestShortcutForAppID_t pOriginalGetBestShortcutForAppID;
 
+// https://stackoverflow.com/questions/20590656/error-for-hash-function-of-pair-of-ints
+struct pair_hash {
+    template<class TFirst, class TSecond>
+    size_t operator()(const std::pair<TFirst, TSecond>& p) const noexcept {
+        uintmax_t hash = std::hash<TFirst>{}(p.first);
+        hash <<= sizeof(uintmax_t) * 4;
+        hash ^= std::hash<TSecond>{}(p.second);
+        return std::hash<uintmax_t>{}(hash);
+    }
+};
+
+std::unordered_map<std::wstring, std::pair<HWND, DWORD>> s_appIdToHwndAndProcess;
+std::unordered_map<std::pair<HWND, DWORD>, std::wstring, pair_hash> s_hwndAndProcessToAppId;
+std::recursive_mutex s_mutex;
+
 HRESULT WINAPI GetAppIDForWindowHook(
     LPVOID pThis,
     _In_ HWND hwnd,
@@ -81,14 +101,76 @@ HRESULT WINAPI GetAppIDForWindowHook(
     );
 
     if (SUCCEEDED(ret)) {
+        std::wstring appIdString = *ppszAppID;
+        DWORD thisProcessID = 0;
+        if (!GetWindowThreadProcessId(hwnd, &thisProcessID)) {
+            return ret;
+        }
+
+        bool originalAppIdHasWindowAttached = false;
+        bool currentWindowIsOriginalAppIdWindow = false;
+        bool windowHasCachedAppId = false;
+        {
+            std::unique_lock<std::recursive_mutex> s_lock(s_mutex);
+
+            // Check if there's a live window for the original AppId
+            if (auto search = s_appIdToHwndAndProcess.find(appIdString); search != s_appIdToHwndAndProcess.end()) {
+                DWORD dwProcessID = 0;
+                if (!GetWindowThreadProcessId(search->second.first, &dwProcessID) || dwProcessID != search->second.second) {
+                    s_appIdToHwndAndProcess.erase(appIdString);
+                } else {
+                    originalAppIdHasWindowAttached = true;
+                }
+
+                if (originalAppIdHasWindowAttached && search->second.first == hwnd) {
+                    currentWindowIsOriginalAppIdWindow = true;
+                }
+            }
+
+            //Wh_Log(L"AppId: %s, originalAppIdHasWindowAttached: %d, currentWindowIsOriginalAppIdWindow: %d", *ppszAppID, originalAppIdHasWindowAttached, currentWindowIsOriginalAppIdWindow);
+
+            // If a window was ever assigned an AppId, return that one
+            if (auto search = s_hwndAndProcessToAppId.find(std::make_pair(hwnd, thisProcessID)); search != s_hwndAndProcessToAppId.end()) {
+                windowHasCachedAppId = true;
+                size_t len = wcslen(*ppszAppID);
+                PWSTR realloc = (PWSTR)CoTaskMemRealloc(*ppszAppID, (search->second.length() + 1) * sizeof(WCHAR));
+                if (realloc) {         
+                    wsprintf(realloc, L"%s", search->second.c_str());
+                    Wh_Log(L"Cached AppId: %s", realloc);
+                    *ppszAppID = realloc;
+                }
+                else {
+                    CoTaskMemFree(*ppszAppID);
+                    ret = E_FAIL;
+                }
+            } 
+
+            if (!windowHasCachedAppId && !originalAppIdHasWindowAttached) {
+                s_appIdToHwndAndProcess.insert(std::make_pair(appIdString, std::make_pair(hwnd, thisProcessID)));
+            }
+
+            if (windowHasCachedAppId) {
+                return ret;
+            }
+            
+            if (!originalAppIdHasWindowAttached || currentWindowIsOriginalAppIdWindow) {
+                s_hwndAndProcessToAppId.insert(std::make_pair(std::make_pair(hwnd, thisProcessID), *ppszAppID));
+                return ret;
+            }
+        }
+
         size_t len = wcslen(*ppszAppID);
         size_t newLen = len + 9;
         if (newLen < MAX_PATH) {
             PWSTR realloc = (PWSTR)CoTaskMemRealloc(*ppszAppID, (newLen + 1) * sizeof(WCHAR));
-            if (realloc) {
+            if (realloc) {         
                 wsprintf(realloc + len, L"_%08X", hwnd);
                 Wh_Log(L"New AppId: %s", realloc);
                 *ppszAppID = realloc;
+                {
+                    std::unique_lock<std::recursive_mutex> s_lock(s_mutex);
+                    s_hwndAndProcessToAppId.insert(std::make_pair(std::make_pair(hwnd, thisProcessID), *ppszAppID));
+                }
             }
             else {
                 CoTaskMemFree(*ppszAppID);


### PR DESCRIPTION
I use pinned items often, and having them always separated was somewhat annoying. The changes are aimed at keeping the pinned items grouped with the first instance of the app. Multiple processes of same app are also handled correctly. There are still some edge cases, though.

The overall idea is to keep track of the app window that's currently using the original unmodified AppId, which makes it grouped with the pin.